### PR TITLE
ci(prek): fine-tune `prek` config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,8 +2,6 @@ default_install_hook_types:
   - pre-commit
   - commit-msg
   - pre-push
-  - post-checkout
-  - post-merge
 
 default_stages:
   - pre-commit
@@ -15,8 +13,7 @@ repos:
     hooks:
       - id: check-hooks-apply
 
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+  - repo: builtin
     hooks:
       - id: trailing-whitespace
         args: [--markdown-linebreak-ext=md]
@@ -24,7 +21,6 @@ repos:
         exclude: "tests/data/.+"
       - id: check-yaml
       - id: check-added-large-files
-      - id: debug-statements
       - id: check-toml
       - id: detect-private-key
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ format.help = "Format the code according to known rules"
 format.composite = [
     "codespell --write-changes --interactive 2",
     # See: https://docs.astral.sh/ruff/formatter/#sorting-imports
-    "ruff check --select I --fix-only --show-fixes src tests",
+    "ruff check --select I,C,UP --fix-only --show-fixes src tests",
     "ruff format src tests"
 ]
 


### PR DESCRIPTION
- Use `prek` builtin hooks
- Remove `post-checkout` and `post-merge` hooks
- Add `ruff` `C` and `UP` rules to formating